### PR TITLE
Update scripts for new screenshot naming

### DIFF
--- a/run - Copy.sh
+++ b/run - Copy.sh
@@ -25,32 +25,36 @@ secondsToTime () {
 }
 
 # logic to go and rename files with correct naming convention:
-  #  - numbers, needs to be SHOOT_CODEXXX.jpg
-  #  - always 3 digits (so 1 would be 001)
-  #  - unless > 999 in which case would be normal numbers
-  #  - for example previously would have been "tnpb13624-18.jpg", now would be "tnpb13624018.jpg"
+  #  - drop the shoot code from the filename
+  #  - pad numbers to always be three digits
+  #  - thumbnails should retain the "tn" prefix
 renameScreencaps () {
   SCREENCAPS_DIR=$1
 
   for filename in "$SCREENCAPS_DIR"/*.jpg; do
+    SC_FILE_NAME=$(basename "$filename")                   # e.g. tnpb13624-18.jpg
+    SC_FILE_NO_EXTENSION="${SC_FILE_NAME%.*}"               # remove extension
+    SC_FILE_NUMBER="${SC_FILE_NO_EXTENSION##*-}"            # number after the hyphen
 
-    SC_FILE_NAME=$(basename "$filename") # get the filename without the dir
-    SC_FILE_NO_EXTENSION=$(echo "$SC_FILE_NAME" | cut -f 1 -d '.') # remove the file extension
-    SC_FILE_PREFIX=${SC_FILE_NO_EXTENSION%-*} # get the prefix
-    SC_FILE_NUMBER=${SC_FILE_NO_EXTENSION/$SC_FILE_PREFIX-/} # get the number
-    SC_NUMBER=${SC_FILE_NUMBER#0} # convert to int
-    if [ "$SC_NUMBER" -lt 10 ]; then
-      SC_NEW_FILE_NAME_NO_EXTENSION=$SC_FILE_PREFIX"00"$SC_NUMBER
-    elif [ "$SC_NUMBER" -lt 100 ]; then
-      SC_NEW_FILE_NAME_NO_EXTENSION=$SC_FILE_PREFIX"0"$SC_NUMBER
+    # remove leading zeros and convert to int
+    SC_NUMBER=$((10#${SC_FILE_NUMBER}))
+
+    if [[ "$SC_FILE_NO_EXTENSION" == tn* ]]; then
+      PREFIX="tn"
     else
-      SC_NEW_FILE_NAME_NO_EXTENSION=$SC_FILE_PREFIX$SC_NUMBER
+      PREFIX=""
     fi
 
-    #echo "[$SC_NUMBER] Will be: $SC_NEW_FILE_NAME_NO_EXTENSION, should check in $filename - to replace $SC_FILE_NO_EXTENSION    with     $SC_NEW_FILE_NAME_NO_EXTENSION"
+    if [ "$SC_NUMBER" -lt 10 ]; then
+      SC_NEW_FILE_NAME_NO_EXTENSION=${PREFIX}00$SC_NUMBER
+    elif [ "$SC_NUMBER" -lt 100 ]; then
+      SC_NEW_FILE_NAME_NO_EXTENSION=${PREFIX}0$SC_NUMBER
+    else
+      SC_NEW_FILE_NAME_NO_EXTENSION=${PREFIX}$SC_NUMBER
+    fi
 
-    FINAL_FILE_NAME="$SCREENCAPS_DIR/$SC_NEW_FILE_NAME_NO_EXTENSION.jpg" # make the final filename
-    mv "$filename" "$FINAL_FILE_NAME" # actually move/rename the file
+    FINAL_FILE_NAME="$SCREENCAPS_DIR/$SC_NEW_FILE_NAME_NO_EXTENSION.jpg"
+    mv "$filename" "$FINAL_FILE_NAME"
   done
 }
 
@@ -218,19 +222,17 @@ echo "VTT and Sprite took $DURATION seconds to run"
 echo ""
 
 
-###########################################################################################################################################
-# get the length of the video so we can figure out screencaps, one every 3 seconds, starting at 8 seconds and ending 6 seconds before end #
-###########################################################################################################################################
+# get the length of the video so we can figure out screencaps, one every 3 seconds, starting at 15 seconds and ending 6 seconds before end #
 VIDEO_LENGTH=$(docker-compose run --workdir="/go" mt-ffmpeg sh -c "ffprobe -i $FILE_LOCATION_INSIDE_DOCKER" | grep "Duration" | egrep -o '([0-9]{2}:[0-9]{2}:[0-9]{2})')
 echo "Video is [$VIDEO_LENGTH]"
 # the video length is hh::mm::ss format so need to convert to seconds
 VIDEO_LENGTH_SECONDS=$(timeToSeconds "$VIDEO_LENGTH")
 echo "Video length seconds: [$VIDEO_LENGTH_SECONDS]"
-# now we need to minus the end buffer, we're already setting the start to "00:00:08" so we minus 6 seconds for the end credits
+# now we need to minus the end buffer, we're already setting the start to "00:00:15" so we minus 6 seconds for the end credits
 ((VIDEO_LENGTH_SECONDS-=6))
 
 # now figure out the start and end time for screencaps
-SCREENCAP_START_TIME='00:00:08'
+SCREENCAP_START_TIME='00:00:15'
 SCREENCAP_END_TIME=$(secondsToTime "$VIDEO_LENGTH_SECONDS")
 NUM_SCREENCAPS=$((VIDEO_LENGTH_SECONDS/SCREENCAPS_INTERVAL))
 echo "Going to do [$NUM_SCREENCAPS] screencaps from [$SCREENCAP_START_TIME] to [$SCREENCAP_END_TIME]"
@@ -243,7 +245,7 @@ echo "Making [$NUM_SCREENCAPS] screencaps..."
 docker-compose run --workdir="/go" mt-ffmpeg sh -c "mt $FILE_LOCATION_INSIDE_DOCKER --single-images=true --verbose=true --overwrite=true --padding=0 --width=1278 --interval=$SCREENCAPS_INTERVAL --from='$SCREENCAP_START_TIME' --to='$SCREENCAP_END_TIME' --output=$DOCKER_DIR_LOCATION/screencaps/$SHOOT_NAME.jpg;"
 # (this is super hacky but only way I could get it to work properly...) - use mogrify to resize the screencaps to make thumbs in a separate dir then move back to main dir and rename tn*
 echo "Generating thumbs for normal screencaps..."
-docker-compose run --workdir="$DOCKER_DIR_LOCATION/screencaps/" mt-ffmpeg sh -c 'mkdir -p thumbs; mogrify -path thumbs -resize 150x110^ -gravity center -extent 150x110 *.jpg; cd thumbs; for filename in *.jpg; do mv "$filename" ../tn"$filename"; done;'
+docker-compose run --workdir="$DOCKER_DIR_LOCATION/screencaps/" mt-ffmpeg sh -c 'mkdir -p thumbs; mogrify -path thumbs -resize 245x180^ -gravity center -extent 245x180 *.jpg; cd thumbs; for filename in *.jpg; do mv "$filename" ../tn"$filename"; done;'
 # HACK to rename the files as they need to be (see function for details)
 renameScreencaps "$LOCAL_FILE_PATH/screencaps"
 # cleanup - remove the empty thumbs dir
@@ -259,7 +261,7 @@ echo "Making [$NUM_SCREENCAPS] screencaps with no watermark..."
 docker-compose run --workdir="/go" mt-ffmpeg sh -c "mt $FILE_LOCATION_NO_WATERMARK_INSIDE_DOCKER --single-images=true --verbose=true --overwrite=true --padding=0 --width=1278 --interval=$SCREENCAPS_INTERVAL --from='$SCREENCAP_START_TIME' --to='$SCREENCAP_END_TIME' --output=$DOCKER_DIR_LOCATION/screencapsnw/$SHOOT_NAME.jpg"
 # (this is super hacky but only way I could get it to work properly...) - use mogrify to resize the screencaps to make thumbs in a separate dir then move back to main dir and rename tn*
 echo "Generating thumbs for no watermark screencaps..."
-docker-compose run --workdir="$DOCKER_DIR_LOCATION/screencapsnw/" mt-ffmpeg sh -c 'mkdir -p thumbs; mogrify -path thumbs -resize 150x110^ -gravity center -extent 150x110 *.jpg; cd thumbs; for filename in *.jpg; do mv "$filename" ../tn"$filename"; done;'
+docker-compose run --workdir="$DOCKER_DIR_LOCATION/screencapsnw/" mt-ffmpeg sh -c 'mkdir -p thumbs; mogrify -path thumbs -resize 245x180^ -gravity center -extent 245x180 *.jpg; cd thumbs; for filename in *.jpg; do mv "$filename" ../tn"$filename"; done;'
 # HACK to rename the files as they need to be (see function for details)
 renameScreencaps "$LOCAL_FILE_PATH/screencapsnw"
 # cleanup - remove the empty thumbs dir
@@ -291,9 +293,9 @@ echo "Going to open $TEST_URL"
 DURATION=$(( SECONDS - START ))
 echo "Total script took $DURATION seconds to run"
 
-if [ "$SYSTEM" == "windows" ]; then
-  FILE_LOCATION="/mnt"$(win2lin "$FILE_LOCATION")
-  echo "You can now see the samples here: [$TEST_URL]"
+if [ "$(uname)" == "Darwin" ]; then
+    open "$TEST_URL"
 else
-  open "$TEST_URL"
+    FILE_LOCATION="/mnt"$(win2lin "$FILE_LOCATION")
+    echo "You can now see the samples here: [$TEST_URL]"
 fi

--- a/web/index.html
+++ b/web/index.html
@@ -20,16 +20,20 @@
         </div>
 
         <script>
+            // basic helper to fetch query parameters
             function getQueryVariable(variable) {
-                var query = window.location.search.substring(1);
-                var vars = query.split("&");
-                for (var i=0;i<vars.length;i++) {
-                    var pair = vars[i].split("=");
-                    if (pair[0] === variable) {
-                        return pair[1];
-                    }
+                const params = new URLSearchParams(window.location.search);
+                if (params.has(variable)) {
+                    return params.get(variable);
                 }
-                alert('Query Variable ' + variable + ' not found');
+                return null;
+            }
+
+            function showError(msg) {
+                const div = document.createElement('div');
+                div.style.color = 'red';
+                div.textContent = msg;
+                document.body.appendChild(div);
             }
         </script>
 
@@ -40,6 +44,10 @@
             var shoot = getQueryVariable('shoot');
             var numScreencaps = parseInt(getQueryVariable('num_screencaps'));
             var numRollovers = parseInt(getQueryVariable('num_rollovers'));
+
+            if (!file || !shoot || isNaN(numScreencaps) || isNaN(numRollovers)) {
+                showError('Missing or invalid query parameters');
+            }
 
             var filePath = "../media/" + shoot + "/";
 
@@ -57,38 +65,41 @@
                         "kind": "thumbnails"
                     }]
                 }]
+            }).on('error', function() {
+                showError('Video failed to load: ' + videoFileLocation);
             });
 
             var screenCapToShow = Math.round((numScreencaps / 2) + 1);
             if (screenCapToShow < 10) { // add trailing 0
-                screenCapToShow = shoot + "00" + screenCapToShow + ".jpg";
+                screenCapToShow = "00" + screenCapToShow + ".jpg";
             } else if (screenCapToShow < 100) { // add trailing 0
-                screenCapToShow = shoot + "0" + screenCapToShow + ".jpg";
+                screenCapToShow = "0" + screenCapToShow + ".jpg";
             } else {
-                screenCapToShow = shoot + "" + screenCapToShow + ".jpg";
+                screenCapToShow = screenCapToShow + ".jpg";
             }
 
             var firstScreencapLocation = filePath + "screencaps/" + screenCapToShow;
             var firstNWScreencapLocation = filePath + "screencapsnw/" + screenCapToShow;
 
+            function createImg(src) {
+                var img = document.createElement('img');
+                img.src = src;
+                img.onerror = function() { showError('Missing image: ' + src); };
+                return img;
+            }
+
             var screenCapsHolder = document.getElementById('screencaps-holder');
-            var img = document.createElement('img');
-            img.src = firstScreencapLocation;
-            screenCapsHolder.appendChild(img);
+            screenCapsHolder.appendChild(createImg(firstScreencapLocation));
 
             var screenNWCapsHolder = document.getElementById('screencaps-nw-holder');
-            img = document.createElement('img');
-            img.src = firstNWScreencapLocation;
-            screenNWCapsHolder.appendChild(img);
+            screenNWCapsHolder.appendChild(createImg(firstNWScreencapLocation));
 
             // do rollovers
             var rolloversLocation = filePath + "rollover/180/";
             var rolloverHolder = document.getElementById('rollover-holder');
 
             for (var i = 1; i < (numRollovers + 1); i++) {
-                var img = document.createElement('img');
-                img.src = rolloversLocation + i + ".jpg";
-                rolloverHolder.appendChild(img);
+                rolloverHolder.appendChild(createImg(rolloversLocation + i + ".jpg"));
             }
 
         </script>


### PR DESCRIPTION
## Summary
- rename screencaps without the shoot code and keep 3-digit numbering
- ensure thumbnails retain `tn` prefix
- update screenshot timing to start at 00:15
- handle missing parameters and assets on the index page
- align backup script with the latest naming logic

## Testing
- `bash -n run.sh`
- `bash -n "run - Copy.sh"`


------
https://chatgpt.com/codex/tasks/task_e_684c7e80db44832e966a5001aea32cf6