### PR TITLE
Fix screencaps rename logic

### DIFF
--- a/run - Copy.sh
+++ b/run - Copy.sh
@@ -24,7 +24,7 @@ secondsToTime () {
   fi
 }
 
-# logic to go and rename files with correct naming convention:
+# rename helper used for screencaps without watermarks
   #  - drop the shoot code from the filename
   #  - pad numbers to always be three digits
   #  - thumbnails should retain the "tn" prefix
@@ -54,6 +54,42 @@ renameScreencaps () {
     fi
 
     FINAL_FILE_NAME="$SCREENCAPS_DIR/$SC_NEW_FILE_NAME_NO_EXTENSION.jpg"
+    mv "$filename" "$FINAL_FILE_NAME"
+  done
+}
+
+# rename helper for watermarked screencaps
+#   - keep the shoot code prefix
+#   - pad numbers to four digits
+#   - thumbnails retain the "tn" prefix
+renameWatermarkedScreencaps () {
+  SCREENCAPS_DIR=$1
+  SHOOT_CODE=$2
+
+  for filename in "$SCREENCAPS_DIR"/*.jpg; do
+    SC_FILE_NAME=$(basename "$filename")                   # e.g. pb13624-18.jpg
+    SC_FILE_NO_EXTENSION="${SC_FILE_NAME%.*}"
+    SC_FILE_NUMBER="${SC_FILE_NO_EXTENSION##*-}"
+
+    SC_NUMBER=$((10#${SC_FILE_NUMBER}))
+
+    if [[ "$SC_FILE_NO_EXTENSION" == tn* ]]; then
+      PREFIX="tn"
+    else
+      PREFIX=""
+    fi
+
+    if [ "$SC_NUMBER" -lt 10 ]; then
+      PADDED="000$SC_NUMBER"
+    elif [ "$SC_NUMBER" -lt 100 ]; then
+      PADDED="00$SC_NUMBER"
+    elif [ "$SC_NUMBER" -lt 1000 ]; then
+      PADDED="0$SC_NUMBER"
+    else
+      PADDED="$SC_NUMBER"
+    fi
+
+    FINAL_FILE_NAME="$SCREENCAPS_DIR/${PREFIX}${SHOOT_CODE}${PADDED}.jpg"
     mv "$filename" "$FINAL_FILE_NAME"
   done
 }
@@ -246,8 +282,8 @@ docker-compose run --workdir="/go" mt-ffmpeg sh -c "mt $FILE_LOCATION_INSIDE_DOC
 # (this is super hacky but only way I could get it to work properly...) - use mogrify to resize the screencaps to make thumbs in a separate dir then move back to main dir and rename tn*
 echo "Generating thumbs for normal screencaps..."
 docker-compose run --workdir="$DOCKER_DIR_LOCATION/screencaps/" mt-ffmpeg sh -c 'mkdir -p thumbs; mogrify -path thumbs -resize 245x180^ -gravity center -extent 245x180 *.jpg; cd thumbs; for filename in *.jpg; do mv "$filename" ../tn"$filename"; done;'
-# HACK to rename the files as they need to be (see function for details)
-renameScreencaps "$LOCAL_FILE_PATH/screencaps"
+# rename the screencaps to use shoot code with padded numbering
+renameWatermarkedScreencaps "$LOCAL_FILE_PATH/screencaps" "$SHOOT_NAME"
 # cleanup - remove the empty thumbs dir
 rm -rf "$LOCAL_FILE_PATH/screencaps/thumbs/"
 

--- a/run.sh
+++ b/run.sh
@@ -24,7 +24,7 @@ secondsToTime () {
   fi
 }
 
-# logic to go and rename files with correct naming convention:
+# rename helper used for screencaps without watermarks
 #   - drop the shoot code from the filename
 #   - pad numbers to always be three digits
 #   - thumbnails should retain the "tn" prefix
@@ -54,6 +54,42 @@ renameScreencaps () {
     fi
 
     FINAL_FILE_NAME="$SCREENCAPS_DIR/$SC_NEW_FILE_NAME_NO_EXTENSION.jpg"
+    mv "$filename" "$FINAL_FILE_NAME"
+  done
+}
+
+# rename helper for watermarked screencaps
+#   - keep the shoot code prefix
+#   - pad numbers to four digits
+#   - thumbnails retain the "tn" prefix
+renameWatermarkedScreencaps () {
+  SCREENCAPS_DIR=$1
+  SHOOT_CODE=$2
+
+  for filename in "$SCREENCAPS_DIR"/*.jpg; do
+    SC_FILE_NAME=$(basename "$filename")                   # e.g. pb13624-18.jpg
+    SC_FILE_NO_EXTENSION="${SC_FILE_NAME%.*}"               # remove extension
+    SC_FILE_NUMBER="${SC_FILE_NO_EXTENSION##*-}"            # number after the hyphen
+
+    SC_NUMBER=$((10#${SC_FILE_NUMBER}))
+
+    if [[ "$SC_FILE_NO_EXTENSION" == tn* ]]; then
+      PREFIX="tn"
+    else
+      PREFIX=""
+    fi
+
+    if [ "$SC_NUMBER" -lt 10 ]; then
+      PADDED="000$SC_NUMBER"
+    elif [ "$SC_NUMBER" -lt 100 ]; then
+      PADDED="00$SC_NUMBER"
+    elif [ "$SC_NUMBER" -lt 1000 ]; then
+      PADDED="0$SC_NUMBER"
+    else
+      PADDED="$SC_NUMBER"
+    fi
+
+    FINAL_FILE_NAME="$SCREENCAPS_DIR/${PREFIX}${SHOOT_CODE}${PADDED}.jpg"
     mv "$filename" "$FINAL_FILE_NAME"
   done
 }
@@ -248,8 +284,8 @@ docker-compose run --workdir="/go" mt-ffmpeg sh -c "mt $FILE_LOCATION_INSIDE_DOC
 # (this is super hacky but only way I could get it to work properly...) - use mogrify to resize the screencaps to make thumbs in a separate dir then move back to main dir and rename tn*
 echo "Generating thumbs for normal screencaps..."
 docker-compose run --workdir="$DOCKER_DIR_LOCATION/screencaps/" mt-ffmpeg sh -c 'mkdir -p thumbs; mogrify -path thumbs -resize 245x180^ -gravity center -extent 245x180 *.jpg; cd thumbs; for filename in *.jpg; do mv "$filename" ../tn"$filename"; done;'
-# HACK to rename the files as they need to be (see function for details)
-renameScreencaps "$LOCAL_FILE_PATH/screencaps"
+# rename the screencaps to use shoot code with padded numbering
+renameWatermarkedScreencaps "$LOCAL_FILE_PATH/screencaps" "$SHOOT_NAME"
 # cleanup - remove the empty thumbs dir
 rm -rf "$LOCAL_FILE_PATH/screencaps/thumbs/"
 

--- a/web/index.html
+++ b/web/index.html
@@ -69,17 +69,29 @@
                 showError('Video failed to load: ' + videoFileLocation);
             });
 
-            var screenCapToShow = Math.round((numScreencaps / 2) + 1);
-            if (screenCapToShow < 10) { // add trailing 0
-                screenCapToShow = "00" + screenCapToShow + ".jpg";
-            } else if (screenCapToShow < 100) { // add trailing 0
-                screenCapToShow = "0" + screenCapToShow + ".jpg";
+            var screenCapIndex = Math.round((numScreencaps / 2) + 1);
+            var screenCapToShowNW;
+            if (screenCapIndex < 10) {
+                screenCapToShowNW = "00" + screenCapIndex + ".jpg";
+            } else if (screenCapIndex < 100) {
+                screenCapToShowNW = "0" + screenCapIndex + ".jpg";
             } else {
-                screenCapToShow = screenCapToShow + ".jpg";
+                screenCapToShowNW = screenCapIndex + ".jpg";
             }
 
-            var firstScreencapLocation = filePath + "screencaps/" + screenCapToShow;
-            var firstNWScreencapLocation = filePath + "screencapsnw/" + screenCapToShow;
+            var screenCapToShow;
+            if (screenCapIndex < 10) {
+                screenCapToShow = "000" + screenCapIndex + ".jpg";
+            } else if (screenCapIndex < 100) {
+                screenCapToShow = "00" + screenCapIndex + ".jpg";
+            } else if (screenCapIndex < 1000) {
+                screenCapToShow = "0" + screenCapIndex + ".jpg";
+            } else {
+                screenCapToShow = screenCapIndex + ".jpg";
+            }
+
+            var firstScreencapLocation = filePath + "screencaps/" + shoot + screenCapToShow;
+            var firstNWScreencapLocation = filePath + "screencapsnw/" + screenCapToShowNW;
 
             function createImg(src) {
                 var img = document.createElement('img');


### PR DESCRIPTION
## Summary
- keep shoot code on watermarked screencaps using four-digit numbering
- still rename no-watermark screencaps to three-digit numbering
- update index page to look for padded watermarked filenames

## Testing
- `bash -n run.sh`
- `bash -n 'run - Copy.sh'`


------
https://chatgpt.com/codex/tasks/task_e_684c90e41ac4832ea2eda025da8742cc