### PR TITLE
Fix three-digit padding on watermarked screencaps

### DIFF
--- a/run - Copy.sh
+++ b/run - Copy.sh
@@ -79,6 +79,8 @@ renameWatermarkedScreencaps () {
     fi
 
     if [ "$SC_NUMBER" -lt 10 ]; then
+      PADDED="00$SC_NUMBER"
+    elif [ "$SC_NUMBER" -lt 100 ]; then
       PADDED="0$SC_NUMBER"
     else
       PADDED="$SC_NUMBER"

--- a/run.sh
+++ b/run.sh
@@ -78,6 +78,8 @@ renameWatermarkedScreencaps () {
     fi
 
     if [ "$SC_NUMBER" -lt 10 ]; then
+      PADDED="00$SC_NUMBER"
+    elif [ "$SC_NUMBER" -lt 100 ]; then
       PADDED="0$SC_NUMBER"
     else
       PADDED="$SC_NUMBER"


### PR DESCRIPTION
## Summary
- pad numbers on watermarked screencaps to three digits

## Testing
- `shellcheck run.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c9f0a5b1c832e8e562e695c1e1b72