### PR TITLE
Update Dockerfile FFmpeg build command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,16 +9,17 @@ ENV FFMPEG_VERSION=4.3.5
 WORKDIR /tmp/ffmpeg
 
 # install ffmpeg
-RUN apk add --update build-base curl nasm tar bzip2 zlib-dev openssl-dev yasm-dev lame-dev libogg-dev x264-dev libvpx-dev libvorbis-dev x265-dev freetype-dev libass-dev libwebp-dev rtmpdump-dev libtheora-dev opus-dev && \
+RUN set -e && \
+  apk add --update build-base curl nasm tar bzip2 zlib-dev openssl-dev yasm-dev lame-dev libogg-dev x264-dev libvpx-dev libvorbis-dev x265-dev freetype-dev libass-dev libwebp-dev rtmpdump-dev libtheora-dev opus-dev && \
   DIR=$(mktemp -d) && cd ${DIR} && \
-  curl -s http://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.gz | tar zxvf - -C . && \
+  curl -L -s https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.gz | tar zxvf - -C . && \
   cd ffmpeg-${FFMPEG_VERSION} && \
   ./configure --enable-version3 --enable-gpl --enable-nonfree --enable-small --enable-libmp3lame --enable-libx264 --enable-libx265 --enable-libvpx --enable-libtheora --enable-libvorbis --enable-libopus --enable-libass --enable-libwebp --enable-librtmp --enable-postproc --enable-swresample --enable-libfreetype --enable-openssl --disable-debug && \
   make && \
   make install && \
   make distclean && \
-  rm -rf ${DIR}
-  # && \ apk del build-base curl tar bzip2 x264 openssl nasm && rm -rf /var/cache/apk/*
+  apk del build-base curl tar bzip2 nasm && \
+  rm -rf /var/cache/apk/* ${DIR}
 
 FROM base_stage as go_stage
 


### PR DESCRIPTION
## Summary
- use secure `https` when downloading FFmpeg
- add `set -e` and cleanup steps during build

## Testing
- `docker build --no-cache -t mt-ffmpeg:test -f Dockerfile .` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cacd91854832eb101ea879f1cea68