### PR TITLE
chore: install mt tool at fixed version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,11 +23,11 @@ RUN set -e && \
 
 FROM base_stage as go_stage
 
-RUN apk add imagemagick
+RUN apk add --no-cache imagemagick build-base
 
 WORKDIR /go
 
 # install the mt tool
 # Prior versions cloned a specific commit of mutschler/mt, but that commit was
 # removed upstream. Installing via `go install` ensures the build succeeds.
-RUN go install github.com/mutschler/mt@latest
+RUN go install github.com/mutschler/mt/v2@v2.0.0


### PR DESCRIPTION
## Summary
- install build deps and pin mt tool to v2.0.0

## Testing
- `docker build .` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689e522bd730832e9c3bf3126f0a11fa