### PR TITLE
chore: remove obsolete compose version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.5"
-
 services:
   mt-ffmpeg:
     image: mt-ffmpeg:latest


### PR DESCRIPTION
## Summary
- remove obsolete version field from docker-compose

## Testing
- `docker compose config` *(fails: command not found)*
- `apt-get install -y docker.io` *(fails: Unable to locate package docker.io)*

------
https://chatgpt.com/codex/tasks/task_e_68b72150397c832ea941fefc622a5d03